### PR TITLE
Add CLI option to mark app as debuggable

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ export type TaskOptions = {
   uberApkSigner: UberApkSigner
   tmpDir: string
   wait: boolean
+  debuggable: boolean
 }
 
 interface PatchingError extends Error {
@@ -34,7 +35,7 @@ const { version } = require('../package.json')
 async function main() {
   const args = parseArgs(process.argv.slice(2), {
     string: ['apktool'],
-    boolean: ['help', 'wait', 'skip-patches'],
+    boolean: ['help', 'wait', 'skip-patches', 'debuggable'],
   })
 
   if (args.help) {
@@ -91,6 +92,7 @@ async function main() {
     uberApkSigner,
     wait: args.wait,
     skipPatches: args.skipPatches,
+    debuggable: args.debuggable,
   })
     .run()
     .then(context => {
@@ -151,6 +153,7 @@ function showHelp() {
       {dim {bold --wait} Wait for manual changes before re-encoding {gray.italic (optional)}}
       {dim {bold --apktool} Path to custom Apktool.jar {gray.italic (optional)}}
       {dim {bold --skip-patches} Don't apply any patches {gray.italic (optional)}}
+      {dim {bold --debuggable} Whether or not the application can be debugged {gray.italic (optional)}}
   `)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,9 +151,9 @@ function showHelp() {
   console.log(chalk`
   $ {bold apk-mitm} <path-to-apk/xapk/apks>
       {dim {bold --wait} Wait for manual changes before re-encoding {gray.italic (optional)}}
+      {dim {bold --debuggable} Make the patched app debuggable {gray.italic (optional)}}
       {dim {bold --apktool} Path to custom Apktool.jar {gray.italic (optional)}}
       {dim {bold --skip-patches} Don't apply any patches {gray.italic (optional)}}
-      {dim {bold --debuggable} Whether or not the application can be debugged {gray.italic (optional)}}
   `)
 }
 

--- a/src/patch-apk.ts
+++ b/src/patch-apk.ts
@@ -29,7 +29,7 @@ export default function patchApk(options: TaskOptions) {
     {
       title: 'Applying patches',
       skip: () => options.skipPatches,
-      task: () => applyPatches(decodeDir),
+      task: () => applyPatches(decodeDir, options.debuggable),
     },
     {
       title: 'Waiting for you to make changes',

--- a/src/tasks/apply-patches.ts
+++ b/src/tasks/apply-patches.ts
@@ -5,13 +5,17 @@ import modifyManifest from './modify-manifest'
 import createNetworkSecurityConfig from './create-netsec-config'
 import disableCertificatePinning from './disable-certificate-pinning'
 
-export default function applyPatches(decodeDir: string) {
+export default function applyPatches(
+  decodeDir: string,
+  debuggable: undefined | boolean,
+) {
   return new Listr([
     {
       title: 'Modifying app manifest',
       task: async context => {
         const result = await modifyManifest(
           path.join(decodeDir, 'AndroidManifest.xml'),
+          debuggable,
         )
 
         context.usesAppBundle = result.usesAppBundle

--- a/src/tasks/apply-patches.ts
+++ b/src/tasks/apply-patches.ts
@@ -5,10 +5,7 @@ import modifyManifest from './modify-manifest'
 import createNetworkSecurityConfig from './create-netsec-config'
 import disableCertificatePinning from './disable-certificate-pinning'
 
-export default function applyPatches(
-  decodeDir: string,
-  debuggable: undefined | boolean,
-) {
+export default function applyPatches(decodeDir: string, debuggable = false) {
   return new Listr([
     {
       title: 'Modifying app manifest',

--- a/src/tasks/modify-manifest.ts
+++ b/src/tasks/modify-manifest.ts
@@ -1,7 +1,10 @@
 import * as fs from '../utils/fs'
 import xml = require('xml-js')
 
-export default async function modifyManifest(path: string) {
+export default async function modifyManifest(
+  path: string,
+  debuggable: undefined | boolean,
+) {
   const document = xml.xml2js(await fs.readFile(path, 'utf-8')) as xml.Element
 
   const manifest = document.elements?.find(el => el.name === 'manifest')!
@@ -10,6 +13,13 @@ export default async function modifyManifest(path: string) {
   application.attributes = {
     ...application.attributes,
     'android:networkSecurityConfig': '@xml/nsc_mitm',
+  }
+
+  if (typeof debuggable !== 'undefined') {
+    application.attributes = {
+      ...application.attributes,
+      'android:debuggable': debuggable.toString(),
+    }
   }
 
   const usesAppBundle =

--- a/src/tasks/modify-manifest.ts
+++ b/src/tasks/modify-manifest.ts
@@ -1,10 +1,7 @@
 import * as fs from '../utils/fs'
 import xml = require('xml-js')
 
-export default async function modifyManifest(
-  path: string,
-  debuggable: undefined | boolean,
-) {
+export default async function modifyManifest(path: string, debuggable = false) {
   const document = xml.xml2js(await fs.readFile(path, 'utf-8')) as xml.Element
 
   const manifest = document.elements?.find(el => el.name === 'manifest')!
@@ -12,14 +9,12 @@ export default async function modifyManifest(
 
   application.attributes = {
     ...application.attributes,
-    'android:networkSecurityConfig': '@xml/nsc_mitm',
-  }
 
-  if (typeof debuggable !== 'undefined') {
-    application.attributes = {
-      ...application.attributes,
-      'android:debuggable': debuggable.toString(),
-    }
+    // Configure app to use custom Network Security Config
+    'android:networkSecurityConfig': '@xml/nsc_mitm',
+
+    // Make app debuggable when `--debuggable` flag is used
+    ...(debuggable && { 'android:debuggable': 'true' }),
   }
 
   const usesAppBundle =


### PR DESCRIPTION
This allows to attach a debugger to the patched APK:

https://developer.android.com/studio/debug#enable-debug

Since Android Studio only supports setting breakpoints if the source code is availabe, this feature probably won't be used by a lot of people... but there is a Smalidea extension which allows you to debug smali.

I added this feature in order to get a nice stack-trace for #34 (which sadly I didn't get yet).

This is a really nice tool by the way, I love it! :clap: 