### PR TITLE
Fix disabling of cert-pinning in minified okhttp

### DIFF
--- a/src/tasks/smali/patches.ts
+++ b/src/tasks/smali/patches.ts
@@ -92,6 +92,19 @@ const smaliPatches: SmaliPatch[] = [
       },
     ],
   },
+  {
+    selector: {
+      type: 'class',
+      name: 't3/s', // Uglified version of 'okhttp3/CertificatePinner'
+    },
+    methods: [
+      {
+        name: 'CertificatePinner#check (OkHttp 3.x)',
+        signature: 'a(Ljava/lang/String;Ljava/util/List;)V',
+        replacementLines: RETURN_VOID_SMALI,
+      },
+    ],
+  },
 ]
 
 export default smaliPatches


### PR DESCRIPTION
This fixes the removal of certificate-pinning as discussed in https://github.com/shroudedcode/apk-mitm/issues/34#issuecomment-770393173.

Since this signature relies on a (randomly?) uglified class- and function-name, it may cause issues and false positives.