### PR TITLE
Pass `--no-res` flag to Apktool

### DIFF
--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -24,6 +24,7 @@ export default class Apktool extends Tool {
         outputPath,
         '--frame-path',
         this.options.frameworkPath,
+        '--no-res'
       ],
       'decoding',
     )


### PR DESCRIPTION
prevent the decompile of resources. This keeps the resources.arsc intact without any decode.