### PR TITLE
Add `--keep` cli argument to keep temporary directory

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,9 +122,9 @@ async function main() {
       console.log(
         chalk`\n  {green.inverse  Done! } Patched file: {bold ./${outputName}}\n`,
       )
+
       if (!args.keep) {
         await rm(tmpDir, { recursive: true, force: true })
-        console.log(chalk.dim(`  Removed temporary directory:\n  ${tmpDir}\n`))
       }
     })
     .catch((error: PatchingError) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import parseArgs = require('yargs-parser')
 import chalk = require('chalk')
 import Listr = require('listr')
 import tempy = require('tempy')
+import { rmSync } from 'fs'
 
 import patchApk, { showAppBundleWarning } from './patch-apk'
 import { patchXapkBundle, patchApksBundle } from './patch-app-bundle'
@@ -38,7 +39,7 @@ const { version } = require('../package.json')
 async function main() {
   const args = parseArgs(process.argv.slice(2), {
     string: ['apktool', 'certificate'],
-    boolean: ['help', 'wait', 'skip-patches', 'debuggable'],
+    boolean: ['help', 'wait', 'skip-patches', 'debuggable', 'keep'],
   })
 
   if (args.help) {
@@ -121,6 +122,10 @@ async function main() {
       console.log(
         chalk`\n  {green.inverse  Done! } Patched file: {bold ./${outputName}}\n`,
       )
+      if (!args.keep) {
+        rmSync(tmpDir, { recursive: true, force: true })
+        console.log(chalk.dim(`  Removed temporary directory:\n  ${tmpDir}\n`))
+      }
     })
     .catch((error: PatchingError) => {
       const message = getErrorMessage(error, { tmpDir })
@@ -178,6 +183,7 @@ function showHelp() {
   {dim {bold --wait} Wait for manual changes before re-encoding}
   {dim {bold --debuggable} Make the patched app debuggable}
   {dim {bold --skip-patches} Don't apply any patches (for troubleshooting)}
+  {dim {bold --keep} Don't delete the temporary directory after patching}
   {dim {bold --apktool <path-to-jar>} Use custom version of Apktool}
   {dim {bold --certificate <path-to-pem/der>} Add specific certificate to network security config}
   `)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import parseArgs = require('yargs-parser')
 import chalk = require('chalk')
 import Listr = require('listr')
 import tempy = require('tempy')
-import { rmSync } from 'fs'
+import { rm } from 'fs/promises'
 
 import patchApk, { showAppBundleWarning } from './patch-apk'
 import { patchXapkBundle, patchApksBundle } from './patch-app-bundle'
@@ -114,7 +114,7 @@ async function main() {
     debuggable: args.debuggable,
   })
     .run()
-    .then(context => {
+    .then(async context => {
       if (taskFunction === patchApk && context.usesAppBundle) {
         showAppBundleWarning()
       }
@@ -123,7 +123,7 @@ async function main() {
         chalk`\n  {green.inverse  Done! } Patched file: {bold ./${outputName}}\n`,
       )
       if (!args.keep) {
-        rmSync(tmpDir, { recursive: true, force: true })
+        await rm(tmpDir, { recursive: true, force: true })
         console.log(chalk.dim(`  Removed temporary directory:\n  ${tmpDir}\n`))
       }
     })


### PR DESCRIPTION
By default, apk-mitm does not remove the tmp directory created while patching application
This PR removes the tmp directory after successful patching, and adds a CLI argument --keep to not delete the directory