### PR TITLE
Bump apktool from 2.6.0 to 2.6.1

### DIFF
--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -58,7 +58,7 @@ export default class Apktool extends Tool {
   get version() {
     if (this.options.customPath) return { name: chalk.italic('custom version') }
 
-    const versionNumber = '2.6.0'
+    const versionNumber = '2.6.1'
 
     return {
       name: `v${versionNumber}`,


### PR DESCRIPTION
Apktool was upgraded to version 2.6.1
https://github.com/iBotPeaches/Apktool/releases/tag/v2.6.1