### PR TITLE
add Dockerfile and instructions in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:19-buster
+RUN apt update && apt install -y default-jre
+RUN npm install -g apk-mitm
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ If you have an up-to-date version of [Node.js][node] (14+) and [Java][java] (8+)
 $ npm install -g apk-mitm
 ```
 
+### Docker
+
+`apk-mitm` can also be used with Docker, without installing any package in your system.
+Check the `Dockerfile` in this repository.
+
+```shell
+docker build -t apk-mitm .
+docker run --rm -it -v $(pwd):/app apk-mitm:latest apk-mitm <path-to-apk>
+```
+
 ## Usage
 
 Once installed, you can run this command to patch an app:


### PR DESCRIPTION
I did not like the idea of installing node and Java on my system, so I explored how to use Docker.
It was pretty easy, I just installed Java on top of `node` official image.

This PR provides the `Dockerfile` I used and some instructions in the README on how to use Docker.