### PR TITLE
Do not decode resources using Apktool

### DIFF
--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -24,6 +24,7 @@ export default class Apktool extends Tool {
         outputPath,
         '--frame-path',
         this.options.frameworkPath,
+        '--no-res',
       ],
       'decoding',
     )


### PR DESCRIPTION
Speed up decoding using Apktool's `--no-res` option, which prevents decoding APK resources. This should improve speed for apps and games that have a large number of resources.