### PR TITLE
Apk-mitm update (Apktool v2.7, AAPT2 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,37 +45,8 @@ jobs:
         # Download Telegram FOSS as an example APK
         # (there might be better APKs for testing, I didn't put a lot of thought into picking this one)
         run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
-      - name: Patch example APK
+      - name: Test with AAPT1
         run: node bin/apk-mitm example.apk
-  test:
-    name: E2E Test (AAPT2) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
-    strategy:
-      matrix:
-        os:
-          - name: Linux
-            runner: ubuntu-latest
-          - name: macOS
-            runner: macos-latest
-          - name: Windows
-            runner: windows-latest
-        node: [14, 16]
-      # Prevent one failing job from cancelling the other ones
-      fail-fast: false
-    runs-on: ${{ matrix.os.runner }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v1
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Install dependencies
-        run: yarn
-      - name: Build package
-        run: yarn build
-      - name: Download example APK
-        # Download Telegram FOSS as an example APK
-        # (there might be better APKs for testing, I didn't put a lot of thought into picking this one)
-        run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
-      - name: Patch example APK
+
+      - name: Test with AAPT2
         run: node bin/apk-mitm --aapt2 example.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
       - name: Patch example APK
         run: node bin/apk-mitm example.apk
+        
   test:
     name: E2E Test (AAPT2) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check code formatting
         run: yarn lint
   test:
-    name: E2E Test / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
+    name: E2E Test (AAPT1) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
     strategy:
       matrix:
         os:
@@ -47,3 +47,35 @@ jobs:
         run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
       - name: Patch example APK
         run: node bin/apk-mitm example.apk
+  test:
+    name: E2E Test (AAPT2) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
+    strategy:
+      matrix:
+        os:
+          - name: Linux
+            runner: ubuntu-latest
+          - name: macOS
+            runner: macos-latest
+          - name: Windows
+            runner: windows-latest
+        node: [14, 16]
+      # Prevent one failing job from cancelling the other ones
+      fail-fast: false
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v1
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn
+      - name: Build package
+        run: yarn build
+      - name: Download example APK
+        # Download Telegram FOSS as an example APK
+        # (there might be better APKs for testing, I didn't put a lot of thought into picking this one)
+        run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
+      - name: Patch example APK
+        run: node bin/apk-mitm --aapt2 example.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
         run: curl --location --output example.apk https://github.com/Telegram-FOSS-Team/Telegram-FOSS/releases/download/v7.0.0/TF-BETA-THERMATK-v7.0.0.apk
       - name: Patch example APK
         run: node bin/apk-mitm example.apk
-        
   test:
     name: E2E Test (AAPT2) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check code formatting
         run: yarn lint
   test:
-    name: E2E Test (AAPT1) / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
+    name: E2E Test / ${{ matrix.os.name }} / Node.js ${{ matrix.node }}
     strategy:
       matrix:
         os:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,14 @@ const { version } = require('../package.json')
 async function main() {
   const args = parseArgs(process.argv.slice(2), {
     string: ['apktool', 'certificate', 'tmp-dir', 'maps-api-key'],
-    boolean: ['help', 'skip-patches', 'wait', 'debuggable', 'keep-tmp-dir'],
+    boolean: [
+      'help',
+      'skip-patches',
+      'wait',
+      'debuggable',
+      'keep-tmp-dir',
+      'aapt2',
+    ],
   })
 
   if (args.help) {
@@ -77,10 +84,23 @@ async function main() {
   await fs.mkdir(tmpDir, { recursive: true })
   process.chdir(tmpDir)
 
-  const apktool = new Apktool({
-    frameworkPath: path.join(tmpDir, 'framework'),
-    customPath: args.apktool,
-  })
+  let apktool
+
+  if (args.aapt2 == true) {
+    console.log(chalk.dim(`Using AAPT2...\n`))
+    apktool = new Apktool({
+      frameworkPath: path.join(tmpDir, 'framework'),
+      customPath: args.apktool,
+      aapt2: true,
+    })
+  } else {
+    console.log(chalk.dim(`Using AAPT...\n`))
+    apktool = new Apktool({
+      frameworkPath: path.join(tmpDir, 'framework'),
+      customPath: args.apktool,
+      aapt2: false,
+    })
+  }
   const uberApkSigner = new UberApkSigner()
 
   showVersions({ apktool, uberApkSigner })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -256,6 +256,7 @@ function showHelp() {
   $ {bold apk-mitm} <path-to-apk/xapk/apks/decoded-directory>
 
   {blue {dim.bold *} Optional flags:}
+  {dim {bold --aapt2} Use AAPT2 to decode
   {dim {bold --wait} Wait for manual changes before re-encoding}
   {dim {bold --tmp-dir <path>} Where temporary files will be stored}
   {dim {bold --keep-tmp-dir} Don't delete the temporary directory after patching}

--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -74,7 +74,7 @@ export default class Apktool extends Tool {
   get version() {
     if (this.options.customPath) return { name: chalk.italic('custom version') }
 
-    const versionNumber = '2.6.1'
+    const versionNumber = '2.7.0'
 
     return {
       name: `v${versionNumber}`,

--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -8,6 +8,7 @@ import Tool from './tool'
 interface ApktoolOptions {
   frameworkPath: string
   customPath?: string
+  aapt2: boolean
 }
 
 export default class Apktool extends Tool {
@@ -16,17 +17,32 @@ export default class Apktool extends Tool {
   }
 
   decode(inputPath: string, outputPath: string) {
-    return this.run(
-      [
-        'decode',
-        inputPath,
-        '--output',
-        outputPath,
-        '--frame-path',
-        this.options.frameworkPath,
-      ],
-      'decoding',
-    )
+    if (this.options.aapt2 != true) {
+      return this.run(
+        [
+          'decode',
+          inputPath,
+          '--output',
+          outputPath,
+          '--frame-path',
+          this.options.frameworkPath,
+        ],
+        'decoding',
+      )
+    } else {
+      return this.run(
+        [
+          'decode',
+          inputPath,
+          '--use-aapt2',
+          '--output',
+          outputPath,
+          '--frame-path',
+          this.options.frameworkPath,
+        ],
+        'decoding',
+      )
+    }
   }
 
   encode(inputPath: string, outputPath: string, useAapt2: boolean) {


### PR DESCRIPTION
### This update allows: 

- To have updated Apktool to its version 7
- Added AAPT2 support for decoding, to fix the error (https://github.com/iBotPeaches/Apktool/issues/1978)
- Update the ci.yml