### PR TITLE
Update apktool to v2.7

### DIFF
--- a/src/tools/apktool.ts
+++ b/src/tools/apktool.ts
@@ -58,7 +58,7 @@ export default class Apktool extends Tool {
   get version() {
     if (this.options.customPath) return { name: chalk.italic('custom version') }
 
-    const versionNumber = '2.6.1'
+    const versionNumber = '2.7.0'
 
     return {
       name: `v${versionNumber}`,


### PR DESCRIPTION
# Update APKTOOL to version 2.7
Consider taking Apktool version 2.7, because despite the implementation of AAPT2 for encoding, some recent applications crash with this same error : https://github.com/iBotPeaches/Apktool/issues/1978

This problem is solved with v2.7.