### PR TITLE
fix: xml parser error not well-formed (invalid token)

### DIFF
--- a/src/tasks/apply-patches.ts
+++ b/src/tasks/apply-patches.ts
@@ -5,6 +5,7 @@ import modifyManifest from './modify-manifest'
 import createNetworkSecurityConfig from './create-netsec-config'
 import disableCertificatePinning from './disable-certificate-pinning'
 import copyCertificateFile from './copy-certificate-file'
+import fixXmlRes from "./fix-xml-res";
 
 export default function applyPatches(
   decodeDir: string,
@@ -48,6 +49,10 @@ export default function applyPatches(
     {
       title: 'Disabling certificate pinning',
       task: (_, task) => disableCertificatePinning(decodeDir, task),
+    },
+    {
+      title: 'Fix strings in XML res',
+      task: (_, task) => fixXmlRes(decodeDir, task),
     },
   ])
 }

--- a/src/tasks/fix-xml-res.ts
+++ b/src/tasks/fix-xml-res.ts
@@ -1,0 +1,42 @@
+import globby = require('globby')
+import { ListrTaskWrapper } from 'listr'
+import * as fs from '../utils/fs'
+
+import observeAsync from '../utils/observe-async'
+import buildGlob from '../utils/build-glob'
+
+const escapeXmlTags = (value: string): string => {
+  return value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+};
+
+const processXmlFile = async (filePath: string): Promise<void> => {
+  const xml = await fs.readFile(filePath, 'utf8');
+  let newXml = xml;
+
+  const stringRegex = /<string name="(.*?)">(.*?)<\/string>/gs;
+  let match: RegExpExecArray | null;
+  while ((match = stringRegex.exec(xml)) !== null) {
+    const [, name, value] = match;
+    if (value.includes('>') || value.includes('<')) {
+      const escapedValue = escapeXmlTags(value);
+      newXml = newXml.replace(value, `<string name="${name}">${escapedValue}</string>`);
+    }
+  }
+
+  await fs.writeFile(filePath, newXml, 'utf8');
+};
+
+export default async function fixXmlRes(
+  directoryPath: string,
+  task: ListrTaskWrapper,
+) {
+  return observeAsync(async log => {
+    const resStringsGlob = buildGlob(directoryPath, 'res/*/strings.xml')
+
+    log('Scanning strings in XML res...')
+    for await (const filePathChunk of globby.stream(resStringsGlob)) {
+      const filePath = filePathChunk as string
+      await processXmlFile(filePath);
+    }
+  })
+}


### PR DESCRIPTION
Fixes files XML strings in res/*/strings.xml

```
W: <tmp_dir>/decode/res/values-zh-rHK/strings.xml:0: error: xml parser error: not well-formed (invalid token).
W: <tmp_dir>/decode/res/values-zh-rHK/strings.xml: error: file failed to compile.
W: <tmp_dir>/decode/res/values-zh-rTW/strings.xml:0: error: xml parser error: not well-formed (invalid token).
W: <tmp_dir>/decode/res/values-zh-rTW/strings.xml: error: file failed to compile.
```

fix issue: #105 
related: https://github.com/iBotPeaches/Apktool/issues/2872